### PR TITLE
Replace the term "contributor" with "volunteer"

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -56,9 +56,15 @@ class Storage {
   async simpleSearch(query, level, _which) {
     const index = this.indexFor(level);
     let which = [true, false];
+
+    // The front-end originally used the term "contributor" to refer to unpaid
+    // contributors. It now uses the term "volunteer" instead. To support older
+    // versions of the front-end, both values are currently accepted. This may
+    // not be needed for long; few bookmarks were likely created before the
+    // change to "volunteer" was made.
     if (_which === "staff") {
       which = [true];
-    } else if (_which === "contributors") {
+    } else if (_which === "volunteers" || _which === "contributors") {
       which = [false];
     }
 


### PR DESCRIPTION
Mitchell said something about these terms many years ago which always
stuck with me. Paraphrased, she said something like this:

"We are all contributors. Some of us are paid. Others volunteer their
time."

Although I can't find any formal guidelines about this, I notice that
Mozilla generally follows Mitchell's guidance. For example, the "Our
Contributors" page lists both paid and unpaid people,[1] we refer to
unpaid work as "volunteer opportunities" on mozilla.org,[2] and the
careers page uses the phrase "paid and volunteer contributors."[3]

[1] https://www.mozilla.org/credits/
[2] https://www.mozilla.org/contribute/
[3] https://careers.mozilla.org/