### PR TITLE
Add 'alternative name' as a default search field

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -100,6 +100,7 @@ function mapDoc(scrubbedProfile) {
 }
 
 const SIMPLE_SEARCH_FIELDS = [
+  "alternativeName",
   "firstName",
   "funTitle",
   "lastName",


### PR DESCRIPTION
Fixes https://github.com/mozilla-iam/dino-park-issues/issues/78