### PR TITLE
chore(build): Update build image to supported image.

### DIFF
--- a/terraform/codebuild/main.tf
+++ b/terraform/codebuild/main.tf
@@ -29,6 +29,19 @@ resource "aws_codebuild_project" "build" {
       name  = "DOCKER_REPO"
       value = aws_ecr_repository.registry.repository_url
     }
+
+    environment_variable {
+      name  = "DOCKERHUB_USERNAME"
+      type  = "SECRETS_MANAGER"
+      value = "/CodeBuild/dockerhub:username"
+    }
+
+    environment_variable {
+      name  = "DOCKERHUB_PASSWORD"
+      type  = "SECRETS_MANAGER"
+      value = "/CodeBuild/dockerhub:password"
+    }
+
   }
 
   source {

--- a/terraform/codebuild/variables.tf
+++ b/terraform/codebuild/variables.tf
@@ -15,6 +15,6 @@ variable "buildspec_file" {
 # Find all the supported images by AWS here: 
 # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
 variable "build_image" {
-  default = "aws/codebuild/standard:1.0"
+  default = "aws/codebuild/standard:4.0"
 }
 


### PR DESCRIPTION
```
Hello,

We are reaching out to you because you ran a build using either the Ubuntu standard 3.0 [1] or AL2 standard 2.0 [2] Docker Image, in the last 30 days. Starting June 20, 2022, AWS CodeBuild will be moving these images to an unsupported status and they will not be cached on the build hosts anymore.

You may continue using these images for your builds, but will notice an increase in provisioning latency after June 20, 2022. These images will also not be getting any new updates. We recommend updating your Build Projects to use the latest build images in order to get the latest language runtimes and tools. For more information on how to do this, please refer to the user guide [3].

If you have any questions or concerns, please contact AWS Support [4].

[1] Platform: Ubuntu 18.04 - Image: aws/codebuild/standard:3.0 - Definition: ubuntu/standard/3.0
[2] Platform: Amazon Linux 2 - Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0 - Definition: al2/standard/2.0
[3] https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
[4] https://aws.amazon.com/support
```